### PR TITLE
Rename display.DisplayBufferRef to display.DisplayBuffer

### DIFF
--- a/components/st7565/display.py
+++ b/components/st7565/display.py
@@ -44,7 +44,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayBuffer, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 


### PR DESCRIPTION
The API changed in https://github.com/esphome/esphome/pull/5002

Fixes: #1 