### PR TITLE
Fix compilation errors on esphome 2023-12-00 plus

### DIFF
--- a/components/st7565/display.py
+++ b/components/st7565/display.py
@@ -39,7 +39,8 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
 
     if CONF_LAMBDA in config:

--- a/components/st7565/display.py
+++ b/components/st7565/display.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_DC_PIN,
     CONF_RESET_PIN
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 AUTO_LOAD = ["display"]
 DEPENDENCIES = ["spi"]

--- a/components/st7565/st7565.h
+++ b/components/st7565/st7565.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/version.h"
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/spi/spi.h"
 
@@ -9,10 +10,16 @@ namespace st7565 {
 
 class ST7565;
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class ST7565 : public display::DisplayBuffer,
+               public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
+                                     spi::DATA_RATE_8MHZ> {
+#else
 class ST7565 : public PollingComponent,
                public display::DisplayBuffer,
                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH, spi::CLOCK_PHASE_TRAILING,
                                      spi::DATA_RATE_8MHZ> {
+#endif
  public:
   static const uint8_t ST7565_SET_COLUMN_ADDRESS_UPPER_NIBBLE = 0x00;
   static const uint8_t ST7565_SET_COLUMN_ADDRESS_LOWER_NIBBLE = 0x10;


### PR DESCRIPTION
Since ESPHome version 2023-12 components shouldn't be explicitly registered. This causes compilation errors.

This PR adds code that conditionally registers or doesn't register the component depending on if the current version of ESPHome expects that.

This closes PR #4